### PR TITLE
Log if CLI, do not log if callback.

### DIFF
--- a/lib/Plugin/Abstract.php
+++ b/lib/Plugin/Abstract.php
@@ -338,7 +338,10 @@ abstract class Plugin_Abstract implements Plugin_Interface
      */
     final public function log($message, $level = NULL, $file = NULL)
     {
-        $this->middleware->log($message, $file);
+        // Log if CLI, do not log if callback (php_sapi_name() === 'fpm-fcgi'), as it expects JSON encoded string.
+        if (php_sapi_name() === 'cli' && $this->getConfig('middleware/system/log') == 'stout') {
+            $this->middleware->log($message, $file);
+        }
     }
 
     /**


### PR DESCRIPTION
If callback, the client expects JSON encoded string. 

https://github.com/ShipStream/openmage-sync/blob/42442153b232379d59c8adea90805f33207005f4/app/code/community/ShipStream/Sync/Helper/Api.php#L76-L79

```php
        $data = json_decode($response, TRUE);
        if (json_last_error() != JSON_ERROR_NONE) {
            throw new Mage_Core_Exception(Mage::helper('shipstream')->__('An error occurred while decoding JSON encoded string.'));
        }
```

Do not log to avoid the exception.